### PR TITLE
Add jaxb api and impl dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,15 @@
     </distributionManagement>
 
     <dependencies>
-	    <dependency>
-		    <groupId>javax.xml.bind</groupId>
-		    <artifactId>jaxb-api</artifactId>
-		    <version>2.3.0</version>
-	    </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.2</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
In order to run on Java 9+, this dependency needs to be stated explicitly. If only the API is added, compiling works, but saving a petri net in PIPE-gui does not. Adding the implementation fixes the latter, too.

Try the following to verify:
```
mvn exec:exec -pl pipe-gui
```
And then try to save a newly created petri net to a file. Without this PR, this will fail.

